### PR TITLE
Remove build_vignettes when installing curatedMetagenomicData

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -33,8 +33,8 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages("pkgdown", dependencies = TRUE)
-          BiocManager::install("waldronlab/curatedMetagenomicData", build_vignettes = TRUE)
           remotes::install_deps(dependencies = TRUE, repos = BiocManager::repositories())
+          BiocManager::install("waldronlab/curatedMetagenomicData", dependencies = TRUE)
         shell: Rscript {0}
 
       - name: Install package


### PR DESCRIPTION
We don't need to build_vignettes in order to create the pkgdown site so I'm removing it from where BiocManager installs curatedMetagenomicData.