### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,38 +1,17 @@
 Package: bugphyzz
 Title: A harmonized data resource and software for enrichment analysis of microbial physiologies
 Version: 1.5.0
-Authors@R: 
-    c(
-        person(
-            given = "Samuel",
-            family = "Gamboa",
-            role = c("aut", "cre"),
-            email = "Samuel.Gamboa.Tuz@gmail.com",
-            comment = c(ORCID = "0000-0002-6863-7943")
-        ),
-        person(
-            given = "Levi",
-            family = "Waldron",
-            role = c("aut"),
-            email = "levi.waldron@sph.cuny.edu",
-            comment = c(ORCID = "0000-0003-2725-0694")
-        ),
-        person(
-            given = "Kelly",
-            family = "Eckenrode",
-            role = c("aut")
-        ),
-        person(
-            given = "Jonathan",
-            family = "Ye",
-            role = c("aut")
-        ),
-        person(
-            given = "Jennifer",
-            family = "Wokaty",
-            role = c("aut")
-        )
-    )
+Authors@R: c(
+    person("Samuel", "Gamboa", , "Samuel.Gamboa.Tuz@gmail.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-6863-7943")),
+    person("Levi", "Waldron", , "levi.waldron@sph.cuny.edu", role = "aut",
+           comment = c(ORCID = "0000-0003-2725-0694")),
+    person("Kelly", "Eckenrode", role = "aut"),
+    person("Jonathan", "Ye", role = "aut"),
+    person("Jennifer", "Wokaty", role = "aut"),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "R01CA230551"))
+  )
 Description: bugphyzz is an electronic database of standardized microbial
   annotations. It facilitates the creation of microbial signatures based on
   shared attributes, which are utilized for bug set enrichment analysis. The


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- R01CA230551

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23616409889](https://github.com/waldronlab/repo-audits/actions/runs/23616409889)).